### PR TITLE
Add modifiable settings

### DIFF
--- a/backend/src/predicTCR_server/settings.py
+++ b/backend/src/predicTCR_server/settings.py
@@ -2,5 +2,3 @@ from __future__ import annotations
 
 
 predicTCR_url = "predictcr.lkeegan.dev"
-predicTCR_submission_interval_minutes = 0
-predicTCR_submission_quota = 1000

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import pytest
 from predicTCR_server import create_app
 import shutil

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -129,6 +129,39 @@ def test_samples_valid(client):
     assert len(response.json) == 4
 
 
+def test_get_settings_valid(client):
+    headers = _get_auth_headers(client)
+    response = client.get("/api/settings", headers=headers)
+    assert response.status_code == 200
+    assert response.json == {
+        "csv_required_columns": "barcode;cdr3;chain",
+        "default_personal_submission_interval_mins": 30,
+        "default_personal_submission_quota": 10,
+        "global_quota": 1000,
+        "id": 1,
+        "sources": "TIL;PMBC;Other",
+        "tumor_types": "Lung;Breast;Other",
+    }
+
+
+def test_update_settings_valid(client):
+    headers = _get_auth_headers(client, "admin@abc.xy", "admin")
+    new_settings = {
+        "csv_required_columns": "BB;CC;QQ",
+        "default_personal_submission_interval_mins": 60,
+        "default_personal_submission_quota": 7,
+        "global_quota": 999,
+        "id": 1,
+        "sources": "a;b;g",
+        "tumor_types": "1;2;6",
+        "invalid-key": "invalid",
+    }
+    response = client.post("/api/admin/settings", headers=headers, json=new_settings)
+    assert response.status_code == 200
+    new_settings.pop("invalid-key")
+    assert client.get("/api/settings", headers=headers).json == new_settings
+
+
 @pytest.mark.parametrize("input_file_type", ["h5", "csv"])
 def test_input_file_invalid(client, input_file_type: str):
     # no auth header

--- a/frontend/src/components/SettingsTable.vue
+++ b/frontend/src/components/SettingsTable.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { FwbButton, FwbInput, FwbRange } from "flowbite-vue";
+import { ref } from "vue";
+import { apiClient, logout } from "@/utils/api-client";
+import type { Settings } from "@/utils/types";
+
+const settings = ref(null as Settings | null);
+
+function get_settings() {
+  apiClient
+    .get("/settings")
+    .then((response) => {
+      settings.value = response.data;
+    })
+    .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
+      console.log(error);
+    });
+}
+
+get_settings();
+
+function update_settings() {
+  apiClient
+    .post("admin/settings", settings.value)
+    .then(() => {
+      get_settings();
+    })
+    .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
+      console.log(error);
+    });
+}
+</script>
+
+<template>
+  <div class="flex flex-col m-2 p-2" v-if="settings">
+    <fwb-range
+      v-model="settings.default_personal_submission_quota"
+      :steps="1"
+      :min="0"
+      :max="99"
+      :label="`Default personal quota: ${settings.default_personal_submission_quota}`"
+      class="mb-2"
+    />
+    <fwb-range
+      v-model="settings.default_personal_submission_interval_mins"
+      :steps="1"
+      :min="0"
+      :max="60"
+      :label="`Default interval between submissions: ${settings.default_personal_submission_interval_mins} minutes`"
+      class="mb-2"
+    />
+    <fwb-range
+      v-model="settings.global_quota"
+      :steps="1"
+      :min="0"
+      :max="9999"
+      :label="`Remaining global quota: ${settings.global_quota}`"
+      class="mb-2"
+    />
+    <fwb-input
+      v-model="settings.tumor_types"
+      class="mb-2"
+      label="Tumor types (separated by ;)"
+    ></fwb-input>
+    <fwb-input
+      v-model="settings.sources"
+      class="mb-2"
+      label="Sources (separated by ;)"
+    ></fwb-input>
+    <fwb-input
+      v-model="settings.csv_required_columns"
+      class="mb-2"
+      label="Required columns in CSV file (separated by ;)"
+    ></fwb-input>
+    <fwb-button @click="update_settings" color="green">
+      Save settings</fwb-button
+    >
+  </div>
+</template>

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -21,3 +21,13 @@ export type User = {
   full_results: boolean;
   submission_interval_minutes: number;
 };
+
+export type Settings = {
+  id: number;
+  default_personal_submission_quota: number;
+  default_personal_submission_interval_mins: number;
+  global_quota: number;
+  tumor_types: string;
+  sources: string;
+  csv_required_columns: string;
+};

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import SamplesTable from "@/components/SamplesTable.vue";
+import SettingsTable from "@/components/SettingsTable.vue";
 import UsersTable from "@/components/UsersTable.vue";
 import ListComponent from "@/components/ListComponent.vue";
 import ListItem from "@/components/ListItem.vue";
@@ -46,8 +47,11 @@ get_samples();
 <template>
   <main>
     <div class="p-4">
-      <ListComponent title="Generate runner API Token">
-        <ListItem>
+      <ListComponent>
+        <ListItem title="Settings">
+          <SettingsTable />
+        </ListItem>
+        <ListItem title="Generate runner API Token">
           <p>
             Here you can generate a new runner user with an API token for
             authentication. Note the token should be kept secret! It is valid


### PR DESCRIPTION
- add `Settings` model to database
  - have a single instance of this in the database
  - on startup create with default values if not already present in database
- add endpoints
  - get `/settings` returns the settings
    - used by frontend
  - post `/admin/settings` overwrites the settings with the supplied values
    - used by admin frontend
- allow admins to modify the settings in the frontend admin interface
  - lists are represented as semi-colon delimited strings
- resolves #13
- also add `global_quota` to Settings, resolves #22
