### PR TITLE
Store job information

### DIFF
--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -14,6 +14,7 @@ def add_test_users(app):
             email = f"{name}@abc.xy"
             db.session.add(
                 User(
+                    id=None,
                     email=email,
                     password_hash=ph.hash(name),
                     activated=True,
@@ -46,6 +47,7 @@ def add_test_samples(app, data_path: pathlib.Path):
                 with open(f"{ref_dir}/input.{input_file_type}", "w") as f:
                     f.write(input_file_type)
             new_sample = Sample(
+                id=None,
                 email="user@abc.xy",
                 name=name,
                 tumor_type=f"tumor_type{sample_id}",

--- a/frontend/src/components/JobsTable.vue
+++ b/frontend/src/components/JobsTable.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import {
+  FwbTable,
+  FwbTableBody,
+  FwbTableCell,
+  FwbTableHead,
+  FwbTableHeadCell,
+  FwbTableRow,
+} from "flowbite-vue";
+import type { Job } from "@/utils/types";
+import { apiClient, logout } from "@/utils/api-client";
+import { ref } from "vue";
+
+const jobs = ref([] as Job[]);
+
+function get_jobs() {
+  apiClient
+    .get("admin/jobs")
+    .then((response) => {
+      jobs.value = response.data.jobs;
+    })
+    .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
+      console.log(error);
+    });
+}
+
+get_jobs();
+</script>
+
+<template>
+  <fwb-table aria-label="Runner jobs">
+    <fwb-table-head>
+      <fwb-table-head-cell>Id</fwb-table-head-cell>
+      <fwb-table-head-cell>SampleId</fwb-table-head-cell>
+      <fwb-table-head-cell>Start</fwb-table-head-cell>
+      <fwb-table-head-cell>Runtime</fwb-table-head-cell>
+      <fwb-table-head-cell>Status</fwb-table-head-cell>
+      <fwb-table-head-cell>Error message</fwb-table-head-cell>
+    </fwb-table-head>
+    <fwb-table-body>
+      <fwb-table-row
+        v-for="job in jobs"
+        :key="job.id"
+        :class="job.status !== 'failed' ? '!bg-slate-50' : '!bg-red-200'"
+      >
+        <fwb-table-cell>{{ job.id }}</fwb-table-cell>
+        <fwb-table-cell>{{ job.sample_id }}</fwb-table-cell>
+        <fwb-table-cell>{{
+          new Date(job.timestamp_start * 1000).toISOString()
+        }}</fwb-table-cell>
+        <fwb-table-cell
+          >{{ (job.timestamp_end - job.timestamp_start) / 60 }}m</fwb-table-cell
+        >
+        <fwb-table-cell>{{ job.status }}</fwb-table-cell>
+        <fwb-table-cell>{{ job.error_message }}</fwb-table-cell>
+      </fwb-table-row>
+    </fwb-table-body>
+  </fwb-table>
+</template>

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -31,3 +31,12 @@ export type Settings = {
   sources: string;
   csv_required_columns: string;
 };
+
+export type Job = {
+  id: number;
+  sample_id: number;
+  timestamp_start: number;
+  timestamp_end: number;
+  status: string;
+  error_message: string;
+};

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -3,6 +3,7 @@ import SamplesTable from "@/components/SamplesTable.vue";
 import SettingsTable from "@/components/SettingsTable.vue";
 import UsersTable from "@/components/UsersTable.vue";
 import ListComponent from "@/components/ListComponent.vue";
+import JobsTable from "@/components/JobsTable.vue";
 import ListItem from "@/components/ListItem.vue";
 import { FwbButton } from "flowbite-vue";
 import { ref } from "vue";
@@ -71,6 +72,9 @@ get_samples();
         </ListItem>
         <ListItem title="Samples">
           <SamplesTable :samples="samples" :admin="true"></SamplesTable>
+        </ListItem>
+        <ListItem title="Runner Jobs">
+          <JobsTable />
         </ListItem>
       </ListComponent>
     </div>

--- a/runner/docker-compose.yml
+++ b/runner/docker-compose.yml
@@ -10,9 +10,11 @@ services:
     deploy:
       mode: replicated
       replicas: ${PREDICTCR_RUNNER_JOBS:-1}
+    restart: always
     networks:
       - predictcr-network
 
 networks:
   predictcr-network:
     name: predictcr
+    external: true

--- a/runner/src/predicTCR_runner/runner.py
+++ b/runner/src/predicTCR_runner/runner.py
@@ -16,9 +16,13 @@ class Runner:
         self.poll_interval = poll_interval
         self.runner_hostname = os.environ.get("HOSTNAME", "unknown")
         self.logger = logging.getLogger(__name__)
+        self.job_id: int | None = None
+        self.sample_id: int | None = None
 
-    def _request_job(self) -> int | None:
+    def _request_job(self) -> bool:
         self.logger.debug(f"Requesting job from {self.api_url}...")
+        self.job_id = None
+        self.sample_id = None
         response = requests.post(
             url=f"{self.api_url}/runner/request_job",
             json={"runner_hostname": self.runner_hostname},
@@ -27,23 +31,28 @@ class Runner:
         )
         if response.status_code == 204:
             self.logger.debug("  -> no job available.")
-            return None
+            return False
         elif response.status_code == 200:
-            sample_id = response.json().get("sample_id", None)
-            self.logger.debug(f"  -> sample id {sample_id} available.")
-            return sample_id
+            self.job_id = response.json().get("job_id", None)
+            self.sample_id = response.json().get("sample_id", None)
+            self.logger.debug(
+                f"  -> job id {self.job_id} for sample id {self.sample_id}."
+            )
+            if self.job_id is not None and self.sample_id is not None:
+                return True
         else:
             self.logger.error(
                 f"request_job failed with {response.status_code}: {response.content}"
             )
-            return None
+            return False
 
-    def _report_job_failed(self, sample_id: int, message: str):
-        self.logger.info(f"...job failed for sample id {sample_id}.")
+    def _report_job_failed(self, message: str):
+        self.logger.info(f"...job {self.job_id} failed for sample id {self.sample_id}.")
         response = requests.post(
             url=f"{self.api_url}/runner/result",
             data={
-                "sample_id": sample_id,
+                "job_id": self.job_id,
+                "sample_id": self.sample_id,
                 "runner_id": self.runner_hostname,
                 "success": "false",
                 "error_message": message,
@@ -54,16 +63,17 @@ class Runner:
         if response.status_code != 200:
             self.logger.error(f"result with {response.status_code}: {response.content}")
 
-    def _upload_result(self, sample_id: int, result_file: str):
+    def _upload_result(self, result_file: str):
         self.logger.info(
-            f"...job finished for sample id {sample_id}, uploading {result_file}..."
+            f"...job {self.job_id} finished for sample id {self.sample_id}, uploading {result_file}..."
         )
         with open(result_file) as result_file:
             response = requests.post(
                 url=f"{self.api_url}/runner/result",
                 files={"file": result_file},
                 data={
-                    "sample_id": sample_id,
+                    "job_id": self.job_id,
+                    "sample_id": self.sample_id,
                     "runner_hostname": self.runner_hostname,
                     "success": True,
                 },
@@ -73,14 +83,16 @@ class Runner:
             if response.status_code != 200:
                 self.logger.error(f"Failed to upload result: {response.content}")
 
-    def _run_job(self, sample_id: int):
-        self.logger.info(f"Starting job for sample id {sample_id}...")
+    def _run_job(self):
+        self.logger.info(
+            f"Starting job {self.job_id} for sample id {self.sample_id}..."
+        )
         self.logger.debug("Downloading input files...")
         with tempfile.TemporaryDirectory(delete=False) as tmpdir:
             for input_file_type in ["h5", "csv"]:
                 response = requests.post(
                     url=f"{self.api_url}/input_{input_file_type}_file",
-                    json={"sample_id": sample_id},
+                    json={"sample_id": self.sample_id},
                     headers=self.auth_header,
                     timeout=30,
                 )
@@ -89,7 +101,6 @@ class Runner:
                         f"Failed to download {input_file_type}: {response.content}"
                     )
                     return self._report_job_failed(
-                        sample_id,
                         f"Failed to download {input_file_type} on {self.runner_hostname}",
                     )
                 input_file_name = f"input.{input_file_type}"
@@ -104,20 +115,20 @@ class Runner:
                 self.logger.debug(f"  - running {tmpdir}/scripts.sh...")
                 subprocess.run(["sh", "./script.sh"], cwd=tmpdir, check=True)
                 self.logger.debug(f"     ...{tmpdir}/script.sh finished.")
-                self._upload_result(sample_id, f"{tmpdir}/result.zip")
+                self._upload_result(f"{tmpdir}/result.zip")
             except Exception as e:
                 self.logger.exception(e)
-                self.logger.error(f"Failed to run job for sample {sample_id}: {e}")
+                self.logger.error(
+                    f"Failed to run job {self.job_id} for sample {self.sample_id}: {e}"
+                )
                 return self._report_job_failed(
-                    sample_id,
                     f"Error during job execution on {self.runner_hostname}: {e}",
                 )
 
     def start(self):
         self.logger.info(f"Polling {self.api_url} for jobs...")
         while True:
-            job_id = self._request_job()
-            if job_id is not None:
-                self._run_job(job_id)
+            if self._request_job():
+                self._run_job()
             else:
                 time.sleep(self.poll_interval)

--- a/runner/tests/test_runner.py
+++ b/runner/tests/test_runner.py
@@ -4,6 +4,8 @@ from predicTCR_runner.runner import Runner
 def test_runner_request_job(requests_mock):
     requests_mock.post("http://api/runner/request_job", status_code=204)
     runner = Runner(api_url="http://api", jwt_token="abc")
-    assert runner._request_job() is None
-    requests_mock.post("http://api/runner/request_job", json={"sample_id": 44})
-    assert runner._request_job() == 44
+    assert runner._request_job() is False
+    requests_mock.post(
+        "http://api/runner/request_job", json={"job_id": 22, "sample_id": 44}
+    )
+    assert runner._request_job() is True


### PR DESCRIPTION
- add Job model and /admin/jobs endpoint
- start/end times, status and error messages are now stored for each job
- admins can view the list of jobs
- resolves #20
