### PR TITLE
Add admin buttons to delete and resubmit samples

### DIFF
--- a/backend/src/predicTCR_server/model.py
+++ b/backend/src/predicTCR_server/model.py
@@ -85,18 +85,18 @@ class Sample(db.Model):
     status: Mapped[Status] = mapped_column(Enum(Status), nullable=False)
     has_results_zip: Mapped[bool] = mapped_column(Boolean, nullable=False)
 
-    def _base_path(self) -> pathlib.Path:
+    def base_path(self) -> pathlib.Path:
         data_path = flask.current_app.config["PREDICTCR_DATA_PATH"]
         return pathlib.Path(f"{data_path}/{self.id}")
 
     def input_h5_file_path(self) -> pathlib.Path:
-        return self._base_path() / "input.h5"
+        return self.base_path() / "input.h5"
 
     def input_csv_file_path(self) -> pathlib.Path:
-        return self._base_path() / "input.csv"
+        return self.base_path() / "input.csv"
 
     def result_file_path(self) -> pathlib.Path:
-        return self._base_path() / "result.zip"
+        return self.base_path() / "result.zip"
 
 
 @dataclass

--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -32,7 +32,7 @@ def add_test_users(app):
 
 def add_test_samples(app, data_path: pathlib.Path):
     with app.app_context():
-        for sample_id, name in zip(
+        for sample_id, name, status in zip(
             [1, 2, 3, 4],
             [
                 "s1",
@@ -40,6 +40,7 @@ def add_test_samples(app, data_path: pathlib.Path):
                 "s3",
                 "s4",
             ],
+            [Status.QUEUED, Status.RUNNING, Status.COMPLETED, Status.FAILED],
         ):
             ref_dir = data_path / f"{sample_id}"
             ref_dir.mkdir(parents=True, exist_ok=True)
@@ -54,7 +55,7 @@ def add_test_samples(app, data_path: pathlib.Path):
                 source=f"source{sample_id}",
                 timestamp=sample_id,
                 timestamp_results=0,
-                status=Status.QUEUED,
+                status=status,
                 has_results_zip=False,
             )
             db.session.add(new_sample)

--- a/frontend/src/components/SamplesTable.vue
+++ b/frontend/src/components/SamplesTable.vue
@@ -2,6 +2,8 @@
 // @ts-ignore
 import {
   FwbA,
+  FwbButton,
+  FwbModal,
   FwbTable,
   FwbTableBody,
   FwbTableCell,
@@ -10,16 +12,59 @@ import {
   FwbTableRow,
 } from "flowbite-vue";
 import {
+  apiClient,
   download_input_csv_file,
   download_input_h5_file,
   download_result,
+  logout,
 } from "@/utils/api-client";
 import type { Sample } from "@/utils/types";
+import { ref } from "vue";
 
 defineProps<{
   samples: Sample[];
   admin: boolean;
 }>();
+
+const emit = defineEmits(["samplesModified"]);
+
+const current_sample_id = ref(null as number | null);
+const show_delete_modal = ref(false);
+const show_resubmit_modal = ref(false);
+function close_modals() {
+  show_resubmit_modal.value = false;
+  show_delete_modal.value = false;
+}
+
+function resubmit_current_sample() {
+  close_modals();
+  apiClient
+    .post(`admin/resubmit-sample/${current_sample_id.value}`)
+    .then(() => {
+      emit("samplesModified");
+    })
+    .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
+      console.log(error);
+    });
+}
+
+function delete_current_sample() {
+  close_modals();
+  apiClient
+    .delete(`admin/samples/${current_sample_id.value}`)
+    .then(() => {
+      emit("samplesModified");
+    })
+    .catch((error) => {
+      if (error.response.status > 400) {
+        logout();
+      }
+      console.log(error);
+    });
+}
 </script>
 
 <template>
@@ -34,6 +79,7 @@ defineProps<{
       <fwb-table-head-cell>Status</fwb-table-head-cell>
       <fwb-table-head-cell>Inputs</fwb-table-head-cell>
       <fwb-table-head-cell>Results</fwb-table-head-cell>
+      <fwb-table-head-cell v-if="admin">Actions</fwb-table-head-cell>
     </fwb-table-head>
     <fwb-table-body>
       <fwb-table-row v-for="sample in samples" :key="sample.id">
@@ -71,7 +117,63 @@ defineProps<{
           </template>
           <template v-else> - </template>
         </fwb-table-cell>
+        <fwb-table-cell v-if="admin">
+          <fwb-button
+            @click="
+              current_sample_id = sample.id;
+              show_resubmit_modal = true;
+            "
+            class="mr-2"
+            >Resubmit</fwb-button
+          >
+          <fwb-button
+            @click="
+              current_sample_id = sample.id;
+              show_delete_modal = true;
+            "
+            class="mr-2"
+            color="red"
+            >Delete</fwb-button
+          >
+        </fwb-table-cell>
       </fwb-table-row>
     </fwb-table-body>
   </fwb-table>
+
+  <fwb-modal size="lg" v-if="show_resubmit_modal" @close="close_modals">
+    <template #header>
+      <div class="flex items-center text-lg">Resubmit sample</div>
+    </template>
+    <template #body
+      >Are you sure you want to resubmit this sample (any existing results will
+      be deleted)?
+    </template>
+    <template #footer>
+      <div class="flex justify-between">
+        <fwb-button @click="close_modals" color="alternative">
+          No, cancel
+        </fwb-button>
+        <fwb-button @click="resubmit_current_sample" color="green">
+          Yes, resubmit
+        </fwb-button>
+      </div>
+    </template>
+  </fwb-modal>
+
+  <fwb-modal size="lg" v-if="show_delete_modal" @close="close_modals">
+    <template #header>
+      <div class="flex items-center text-lg">Delete sample</div>
+    </template>
+    <template #body> Are you sure you want to delete this sample? </template>
+    <template #footer>
+      <div class="flex justify-between">
+        <fwb-button @click="close_modals" color="alternative">
+          No, cancel
+        </fwb-button>
+        <fwb-button @click="delete_current_sample" color="red">
+          Yes, delete
+        </fwb-button>
+      </div>
+    </template>
+  </fwb-modal>
 </template>

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -71,7 +71,11 @@ get_samples();
           <UsersTable :is_runner="false"></UsersTable>
         </ListItem>
         <ListItem title="Samples">
-          <SamplesTable :samples="samples" :admin="true"></SamplesTable>
+          <SamplesTable
+            :samples="samples"
+            :admin="true"
+            @samples-modified="get_samples"
+          ></SamplesTable>
         </ListItem>
         <ListItem title="Runner Jobs">
           <JobsTable />

--- a/runner/docker-compose.yml
+++ b/runner/docker-compose.yml
@@ -17,4 +17,3 @@ services:
 networks:
   predictcr-network:
     name: predictcr
-    external: true


### PR DESCRIPTION
- add DELETE `admin/samples/<sample_id>` API endpoint
  - deletes the sample and all associated input files and results
- add delete button to admin interface with modal confirmation dialog
  - resolves #39
- add POST `admin/resubmit-sample/<sample_id>` API endpoint
  - deletes any existing results for the sample, then sets its status to QUEUED
- add resubmit button to admin interface with modal confirmation dialog
  - resolves #40