### PR TITLE
Add job runtime info to sample

### DIFF
--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -54,7 +54,8 @@ def add_test_samples(app, data_path: pathlib.Path):
                 tumor_type=f"tumor_type{sample_id}",
                 source=f"source{sample_id}",
                 timestamp=sample_id,
-                timestamp_results=0,
+                timestamp_job_start=0,
+                timestamp_job_end=0,
                 status=status,
                 has_results_zip=False,
             )

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -44,7 +44,7 @@ const login_title = computed(() => {
       </fwb-navbar-collapse>
     </template>
   </fwb-navbar>
-  <div class="flex flex-col items-center justify-center">
+  <div class="flex flex-col items-stretch justify-center">
     <RouterView />
   </div>
 </template>

--- a/frontend/src/components/SettingsTable.vue
+++ b/frontend/src/components/SettingsTable.vue
@@ -86,7 +86,7 @@ function update_settings() {
       :label="`Timeout for runner jobs: ${settings.runner_job_timeout_mins} minutes`"
       class="mb-2"
     />
-    <fwb-button @click="update_settings" color="green">
+    <fwb-button @click="update_settings" class="mt-2" color="green">
       Save settings</fwb-button
     >
   </div>

--- a/frontend/src/components/UsersTable.vue
+++ b/frontend/src/components/UsersTable.vue
@@ -12,7 +12,7 @@ import {
   FwbRange,
 } from "flowbite-vue";
 import type { User } from "@/utils/types";
-import { apiClient, logout } from "@/utils/api-client";
+import { apiClient, download_string_as_file, logout } from "@/utils/api-client";
 import { ref, computed } from "vue";
 
 const props = defineProps<{
@@ -62,6 +62,17 @@ function update_user() {
       }
       console.log(error);
     });
+}
+
+function download_users_as_csv() {
+  let csv =
+    "Id,Email,Activated,Enabled,FullResults,Quota,SubmissionIntervalMinutes,Admin\n";
+  for (const user of users.value) {
+    if (!user.is_runner) {
+      csv += `${user.id},${user.email},${user.activated},${user.enabled},${user.full_results},${user.quota},${user.submission_interval_minutes},${user.is_admin}\n`;
+    }
+  }
+  download_string_as_file("users.csv", csv);
 }
 </script>
 
@@ -114,6 +125,9 @@ function update_user() {
       </fwb-table-row>
     </fwb-table-body>
   </fwb-table>
+  <fwb-button class="mt-2" @click="download_users_as_csv"
+    >Download as CSV</fwb-button
+  >
 
   <fwb-modal size="lg" v-if="show_modal" @close="close_modal">
     <template #header>

--- a/frontend/src/utils/api-client.ts
+++ b/frontend/src/utils/api-client.ts
@@ -80,3 +80,12 @@ export function logout() {
   user.user = null;
   user.token = "";
 }
+
+export function download_string_as_file(filename: string, str: string) {
+  const link = document.createElement("a");
+  const file = new Blob([str], { type: "text/plain" });
+  link.href = URL.createObjectURL(file);
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -5,7 +5,8 @@ export type Sample = {
   tumor_type: string;
   source: number;
   timestamp: number;
-  timestamp_results: number;
+  timestamp_job_start: number;
+  timestamp_job_end: number;
   status: string;
   has_results_zip: boolean;
 };

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -23,7 +23,7 @@ function openModalSignup() {
 </script>
 
 <template>
-  <main>
+  <main class="flex flex-col items-center justify-center">
     <fwb-jumbotron
       header-text="predicTCR v2"
       header-classes="text-slate-100"

--- a/frontend/src/views/ActivateView.vue
+++ b/frontend/src/views/ActivateView.vue
@@ -29,7 +29,7 @@ apiClient
 </script>
 
 <template>
-  <main>
+  <main class="flex flex-col items-center justify-center">
     <CardComponent :title="title">
       <p>{{ message }}</p>
       <p>Go to <RouterLink to="/login">login</RouterLink> page.</p>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -8,7 +8,7 @@ const userStore = useUserStore();
 </script>
 
 <template>
-  <main>
+  <main class="flex flex-col items-center justify-center">
     <template v-if="userStore.user !== null">
       <AccountComponent></AccountComponent>
     </template>

--- a/frontend/src/views/ResetPasswordView.vue
+++ b/frontend/src/views/ResetPasswordView.vue
@@ -62,7 +62,7 @@ function reset_password() {
 </script>
 
 <template>
-  <main>
+  <main class="flex flex-col items-center justify-center">
     <CardComponent :title="title" :icon="icon">
       <form @submit.prevent="reset_password" v-if="show_form">
         <p>

--- a/frontend/src/views/SamplesView.vue
+++ b/frontend/src/views/SamplesView.vue
@@ -207,7 +207,7 @@ function add_sample() {
 </script>
 
 <template>
-  <main>
+  <main class="flex flex-col items-center justify-center">
     <ListComponent>
       <ListItem title="Submit a sample">
         <template v-if="submit_message.length > 0">


### PR DESCRIPTION
- Sample.timestamp_results -> Sample.timestamp_job_start
- add Sample.timestamp_job_end
- add runtime in format hh::mm:ss to admin Samples table
- add button to download samples data as csv to admin view
- also a download as csv button for the admin users table
- resolves #47
