### PR TITLE
Runner uploads last line of script output as error message if script …

### DIFF
--- a/backend/src/predicTCR_server/app.py
+++ b/backend/src/predicTCR_server/app.py
@@ -285,6 +285,7 @@ def create_app(data_path: str = "/predictcr_data"):
         sample.trusted_user_result_file_path().unlink(missing_ok=True)
         sample.admin_result_file_path().unlink(missing_ok=True)
         sample.has_results_zip = False
+        sample.error_message = ""
         sample.status = Status.QUEUED
         db.session.commit()
         return jsonify(message="Sample added to the queue")

--- a/backend/src/predicTCR_server/model.py
+++ b/backend/src/predicTCR_server/model.py
@@ -85,6 +85,7 @@ class Sample(db.Model):
     timestamp_job_end: Mapped[int] = mapped_column(Integer, nullable=False)
     status: Mapped[Status] = mapped_column(Enum(Status), nullable=False)
     has_results_zip: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    error_message: Mapped[str] = mapped_column(String, nullable=False)
 
     def base_path(self) -> pathlib.Path:
         data_path = flask.current_app.config["PREDICTCR_DATA_PATH"]
@@ -216,9 +217,11 @@ def process_result(
     job.timestamp_end = timestamp_now()
     if success:
         job.status = Status.COMPLETED
+        sample.error_message = ""
     else:
         job.status = Status.FAILED
         job.error_message = error_message
+        sample.error_message = error_message
     db.session.commit()
     if sample.has_results_zip:
         logger.warning(f" --> Sample {sample_id} already has results")
@@ -503,6 +506,7 @@ def add_new_sample(
         timestamp_job_end=0,
         status=Status.QUEUED,
         has_results_zip=False,
+        error_message="",
     )
     db.session.add(new_sample)
     db.session.commit()

--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -58,6 +58,7 @@ def add_test_samples(app, data_path: pathlib.Path):
                 timestamp_job_end=0,
                 status=status,
                 has_results_zip=False,
+                error_message="",
             )
             db.session.add(new_sample)
             db.session.commit()

--- a/frontend/src/components/SamplesTable.vue
+++ b/frontend/src/components/SamplesTable.vue
@@ -105,6 +105,7 @@ function download_samples_as_csv() {
       <fwb-table-head-cell v-if="admin">Runtime</fwb-table-head-cell>
       <fwb-table-head-cell>Inputs</fwb-table-head-cell>
       <fwb-table-head-cell>Results</fwb-table-head-cell>
+      <fwb-table-head-cell>Error message</fwb-table-head-cell>
       <fwb-table-head-cell v-if="admin">Actions</fwb-table-head-cell>
     </fwb-table-head>
     <fwb-table-body>
@@ -155,6 +156,7 @@ function download_samples_as_csv() {
           </template>
           <template v-else> - </template>
         </fwb-table-cell>
+        <fwb-table-cell>{{ sample.error_message }}</fwb-table-cell>
         <fwb-table-cell v-if="admin">
           <fwb-button
             @click="

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -9,6 +9,7 @@ export type Sample = {
   timestamp_job_end: number;
   status: string;
   has_results_zip: boolean;
+  error_message: string;
 };
 
 export type User = {


### PR DESCRIPTION
…fails

- runner
  - capture and display stdout while script is running
  - upload last line of output as the error_message if script return code is non-zero
- backend
  - add `error_message` to Sample model
  - store the uploaded error message from the runner here (was already stored in the job, but not the sample)
- frontend
  - display `error_message` in Samples table
- resolves #54