### PR TITLE
Add filesize limits to settings

### DIFF
--- a/backend/src/predicTCR_server/app.py
+++ b/backend/src/predicTCR_server/app.py
@@ -445,6 +445,8 @@ def create_app(data_path: str = "/predictcr_data"):
                     sources="TIL;PMBC;Other",
                     csv_required_columns="barcode;cdr3;chain",
                     runner_job_timeout_mins=60,
+                    max_filesize_h5_mb=50,
+                    max_filesize_csv_mb=10,
                     about_md="",
                 )
             )

--- a/backend/src/predicTCR_server/model.py
+++ b/backend/src/predicTCR_server/model.py
@@ -53,6 +53,8 @@ class Settings(db.Model):
     sources: Mapped[str] = mapped_column(String, nullable=False)
     csv_required_columns: Mapped[str] = mapped_column(String, nullable=False)
     runner_job_timeout_mins: Mapped[int] = mapped_column(Integer, nullable=False)
+    max_filesize_h5_mb: Mapped[int] = mapped_column(Integer, nullable=False)
+    max_filesize_csv_mb: Mapped[int] = mapped_column(Integer, nullable=False)
     about_md: Mapped[str] = mapped_column(String, nullable=False)
 
     def as_dict(self):

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -142,6 +142,8 @@ def test_get_settings_valid(client):
         "sources": "TIL;PMBC;Other",
         "tumor_types": "Lung;Breast;Other",
         "runner_job_timeout_mins": 60,
+        "max_filesize_h5_mb": 50,
+        "max_filesize_csv_mb": 10,
         "about_md": "",
     }
 
@@ -157,6 +159,8 @@ def test_update_settings_valid(client):
         "sources": "a;b;g",
         "tumor_types": "1;2;6",
         "runner_job_timeout_mins": 12,
+        "max_filesize_h5_mb": 77,
+        "max_filesize_csv_mb": 12,
         "about_md": "# About",
         "invalid-key": "invalid",
     }

--- a/frontend/src/components/SettingsTable.vue
+++ b/frontend/src/components/SettingsTable.vue
@@ -2,6 +2,7 @@
 import { FwbButton, FwbInput, FwbRange, FwbTextarea } from "flowbite-vue";
 import { useSettingsStore } from "@/stores/settings";
 import { apiClient, logout } from "@/utils/api-client";
+
 const settingsStore = useSettingsStore();
 settingsStore.refresh();
 
@@ -69,6 +70,22 @@ function update_settings() {
       :label="`Timeout for runner jobs: ${settingsStore.settings.runner_job_timeout_mins} minutes`"
       class="mb-2"
     />
+    <fwb-range
+      v-model="settingsStore.settings.max_filesize_h5_mb"
+      :steps="1"
+      :min="1"
+      :max="100"
+      :label="`Max h5 upload filesize: ${settingsStore.settings.max_filesize_h5_mb}mb`"
+      class="mb-2"
+    />
+    <fwb-range
+      v-model="settingsStore.settings.max_filesize_csv_mb"
+      :steps="1"
+      :min="1"
+      :max="100"
+      :label="`Max csv upload filesize: ${settingsStore.settings.max_filesize_csv_mb}mb`"
+      class="mb-2"
+    />
     <fwb-textarea
       v-model="settingsStore.settings.about_md"
       :rows="32"
@@ -76,7 +93,7 @@ function update_settings() {
       label="About page text (markdown)"
     ></fwb-textarea>
     <fwb-button @click="update_settings" class="mt-2" color="green">
-      Save settings</fwb-button
-    >
+      Save settings
+    </fwb-button>
   </div>
 </template>

--- a/frontend/src/stores/settings.ts
+++ b/frontend/src/stores/settings.ts
@@ -14,6 +14,8 @@ export const useSettingsStore = defineStore("settings", () => {
     csv_required_columns: "",
     runner_job_timeout_mins: 1,
     about_md: "",
+    max_filesize_h5_mb: 1,
+    max_filesize_csv_mb: 1,
   } as Settings);
 
   function refresh() {

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -35,6 +35,8 @@ export type Settings = {
   csv_required_columns: string;
   runner_job_timeout_mins: number;
   about_md: string;
+  max_filesize_h5_mb: number;
+  max_filesize_csv_mb: number;
 };
 
 export type Job = {

--- a/frontend/src/views/SamplesView.vue
+++ b/frontend/src/views/SamplesView.vue
@@ -46,7 +46,7 @@ const csv_file_input_key = ref(0);
 const new_sample_error_message = ref("");
 
 function on_h5_file_changed(event: Event) {
-  const max_upload_size_mb = 50;
+  const max_upload_size_mb = settingsStore.settings.max_filesize_h5_mb;
   const target = event.target as HTMLInputElement;
   if (target.files != null && target.files.length > 0) {
     selected_h5_file.value = target.files[0];
@@ -81,7 +81,7 @@ async function validate_csv_file(file: File) {
 }
 
 async function on_csv_file_changed(event: Event) {
-  const max_upload_size_mb = 10;
+  const max_upload_size_mb = settingsStore.settings.max_filesize_csv_mb;
   const target = event.target as HTMLInputElement;
   if (target.files != null && target.files.length > 0) {
     selected_csv_file.value = target.files[0];


### PR DESCRIPTION
- add to Settings
  - max_filesize_h5_mb = 50
  - max_filesize_csv_mb = 10
- admin interface sliders to select values in range 1-100
- note there is also a hard-coded upload limit in nginx.conf, currently set to 100mb
- resolves #60
