### PR TITLE
Use micromamba docker image for runner

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -1,20 +1,20 @@
-#FROM mambaorg/micromamba:1.5.8-jammy
-FROM continuumio/miniconda3
+FROM ghcr.io/mamba-org/micromamba:debian11-slim
 
 LABEL org.opencontainers.image.source=https://github.com/ssciwr/predicTCR
 LABEL org.opencontainers.image.description="predicTCR runner image"
 LABEL org.opencontainers.image.licenses=MIT
 
-COPY env.yaml /tmp/env.yaml
+COPY --chown=$MAMBA_USER:$MAMBA_USER env.yaml /tmp/env.yaml
 
-RUN conda env create -f /tmp/env.yaml
+RUN micromamba install -y -n base -f /tmp/env.yaml && \
+    micromamba clean --all --yes
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 WORKDIR /app
 
-COPY . .
-
-SHELL ["conda", "run", "-n", "predictcr", "/bin/bash", "-c"]
+COPY --chown=$MAMBA_USER:$MAMBA_USER . .
 
 RUN python -m pip install . && rm -rf *
 
-ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "predictcr", "predicTCR_runner"]
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "predicTCR_runner"]

--- a/runner/README.md
+++ b/runner/README.md
@@ -43,7 +43,7 @@ To update to the latest runner docker images: `docker compose pull && docker com
 To test locally using Docker, you can directly talk to the backend service (this works because both docker-compose files use the same docker network)
 
 ```
-PREDICTCR_RUNNER_API_URL="http://backend:8080/api"
-PREDICTCR_RUNNER_JWT_TOKEN="" # you need to generate this using the admin page of your local instance
-PREDICTCR_RUNNER_LOG_LEVEL=DEBUG
+PREDICTCR_API_URL="http://backend:8080/api"
+PREDICTCR_JWT_TOKEN="" # you need to generate this using the admin page of your local instance
+PREDICTCR_LOG_LEVEL=DEBUG
 ```

--- a/runner/env.yaml
+++ b/runner/env.yaml
@@ -1,8 +1,6 @@
-name: predictcr
+name: base
 channels:
   - conda-forge
-  - r
-  - pkgs/r
   - bioconda
 dependencies:
   - bioconductor-glmgampoi


### PR DESCRIPTION
- also remove `r` and `pkgs/r` channels as they depend on anaconda
- no longer any link to/use of anaconda in this project
- update env var names in developer section of runner readme
- resolves #74
